### PR TITLE
Margins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -34,11 +34,8 @@ This      is a second paragraph with extraneous whitespace.`);
       paragraphsFormatted.push(paragraphFormatted);
     })
 
-    if (paragraphsFormatted.length > 1) {
-      output = paragraphsFormatted.join(DOUBLE_LINE_BREAK);
-    } else {
-      output = paragraphsFormatted;
-    }
+    output = paragraphsFormatted.join(DOUBLE_LINE_BREAK);
+
     setTextOutput(output);
   }
 
@@ -54,22 +51,20 @@ This      is a second paragraph with extraneous whitespace.`);
       const lineLength = currentLineLength + wordLength;
 
       if (lineLength <= MAX_LENGTH_BY_LINE) {
-        if (line === "") {
-          line = word;
-        } else {
-          line = line + " " + word;
-        }
+        line += word + " ";
       } else {
         paragraphFormatted = paragraphFormatted + line;
+
         if (line === "") {
           line = word;
         } else {
-          line = "\n" + word;
+          line = "\n" + word + " ";
         }
       }
     })
     paragraphFormatted = paragraphFormatted + line;
-    return paragraphFormatted;
+
+    return paragraphFormatted.trim();
   }
 
   const handleReset = () => {
@@ -84,9 +79,9 @@ This      is a second paragraph with extraneous whitespace.`);
       </header>
       <form onSubmit={handleSubmit}>
         <label>
-          <textarea onChange={handleChange} value={textInput}/>
+          <textarea onChange={handleChange} value={textInput} />
         </label>
-        <input type="submit" value="Submit"/>
+        <input type="submit" value="Submit" />
         <input type="reset" value="Reset" onClick={handleReset} />
       </form>
       <div id="result">

--- a/src/App.js
+++ b/src/App.js
@@ -13,33 +13,41 @@ a badly formatted file. This line is pretty long! It's way more than 80 characte
 
 This      is a second paragraph with extraneous whitespace.`);
   const [textOutput, setTextOutput] = React.useState('');
+  const [margin, setMargin] = React.useState(0);
 
   const handleChange = event => {
     setTextInput(event.target.value);
   };
 
+  const handleMargin = event => {
+    setMargin(parseInt(event.target.value));
+  }
+
   const handleSubmit = event => {
     event.preventDefault();
-    transformText(textInput);
+    transformText(textInput, margin);
   };
 
-  const transformText = input => {
+  const transformText = (input = "", margin = 0) => {
     let output = "";
     const paragraphsFormatted = []
     const paragraphs = input.split(DOUBLE_LINE_BREAK);
     const paragraphsValid = paragraphs.filter(paragraph => paragraph !== EMPTY)
 
     paragraphsValid.forEach(paragraph => {
-      const paragraphFormatted = transformParagraph(paragraph);
+      const maxLengthByLineWithMargin = MAX_LENGTH_BY_LINE - margin;
+      const paragraphFormatted = transformParagraph(paragraph, maxLengthByLineWithMargin, margin);
       paragraphsFormatted.push(paragraphFormatted);
     })
 
-    output = paragraphsFormatted.join(DOUBLE_LINE_BREAK);
+    output = generatorMargin(margin, LINE_BREAK)
+      + paragraphsFormatted.join(DOUBLE_LINE_BREAK)
+      + generatorMargin(margin + 1, LINE_BREAK);
 
     setTextOutput(output);
   }
 
-  const transformParagraph = (paragraph = "") => {
+  const transformParagraph = (paragraph = "", maxLengthByLine = 0, margin = 0) => {
     let paragraphFormatted = "";
     const paragraphReplaceLineBreak = paragraph.replaceAll(LINE_BREAK, SPACE);
     const words = paragraphReplaceLineBreak.split(SPACE);
@@ -49,27 +57,42 @@ This      is a second paragraph with extraneous whitespace.`);
       const currentLineLength = line.length;
       const wordLength = word.length;
       const lineLength = currentLineLength + wordLength;
-
-      if (lineLength <= MAX_LENGTH_BY_LINE) {
+      if (lineLength + margin <= maxLengthByLine) {
         line += word + " ";
       } else {
-        paragraphFormatted = paragraphFormatted + line;
+        paragraphFormatted = paragraphFormatted + addLeftMargin(line.trimEnd(), margin, SPACE);
 
         if (line === "") {
           line = word;
         } else {
-          line = "\n" + word + " ";
+          line = "\n" + generatorMargin(margin, SPACE) + word + " ";
         }
       }
     })
-    paragraphFormatted = paragraphFormatted + line;
+    paragraphFormatted = paragraphFormatted + addLeftMargin(line.trimEnd(), margin, SPACE);
 
-    return paragraphFormatted.trim();
+    return paragraphFormatted;
+  }
+
+  const addLeftMargin = (line = "", margin = 0, character = " ") => {
+    return generatorMargin(margin, character) + line;
+  }
+
+  const generatorMargin = (quantity = 0, character = " ") => {
+    let margin = "";
+    let counter = 0;
+
+    while (counter < quantity) {
+      margin += character;
+      counter++;
+    }
+    return margin;
   }
 
   const handleReset = () => {
     setTextInput("");
     setTextOutput("");
+    setMargin(0);
   };
 
   return (
@@ -78,6 +101,8 @@ This      is a second paragraph with extraneous whitespace.`);
         <h1>Career Lab | Take-Home Assignment</h1>
       </header>
       <form onSubmit={handleSubmit}>
+        <label htmlFor="margin">Margin:</label>
+        <input type="number" name="margin" id="margin" value={margin} onChange={handleMargin} />
         <label>
           <textarea onChange={handleChange} value={textInput} />
         </label>


### PR DESCRIPTION
Add an additional input called "`margin`" that allows users to specify the number of blank lines at the top and bottom of the output, and empty space at the right and left sides. Left side margins should be created with spaces, but right side margins should be created by simply not allowing a line to extend into them (but do not add any trailing whitespace). For example, with a margin of 4, there should be 4 blank lines at the top of the output, 4 blank lines at the bottom, 4 spaces at the beginning of each line, and no line should have more than 76 characters total (since the right margin is also 4 spaces wide, even though there are no actual space characters there).